### PR TITLE
Swap Value and Index Params for Loops

### DIFF
--- a/beard.js
+++ b/beard.js
@@ -115,18 +115,12 @@ const parse = {
       _context.locals.pop();
     `;
   },
-  for: (_, key, value, object) => {
-    if (!value) {
-      value = key;
-      key = `_iterator_${uniqueIterator(value)}`;
-    }
+  for: (_, value, key, object) => {
+    if (!key) key = `_iterator_${uniqueIterator(value)}`;
     return `for (var ${key} in ${object}) { var ${value} = ${object}[${key}];`;
   },
-  each: (_, iter, value, array) => {
-    if (!value) {
-      value = iter;
-      iter = `_iterator_${uniqueIterator(value)}`;
-    }
+  each: (_, value, iter, array) => {
+    if (!iter) iter = `_iterator_${uniqueIterator(value)}`;
     const length = `_iterator_${uniqueIterator(value)}`;
     return `for (var ${iter} = 0, ${length} = ${array}.length; ${iter} < ${length}; ${iter}++) { var ${value} = ${array}[${iter}];`;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -57,15 +57,20 @@ describe('Beard Rendering', function() {
 
   it('handles for loops', function() {
     const engine = beard({ templates: {
-      '/view': 'names = {{for name in names}} {{name}}{{end}}'
+      '/with-index': 'names = {{for name, index in names}} {{name}} - {{index}}{{end}}',
+      '/no-index': 'names = {{for name in names}} {{name}}{{end}}'
     }});
-    expect(engine.render('view', {names: ['Bill', 'John', 'Dave']})).to.equal('names =  Bill John Dave');
+    expect(engine.render('with-index', {names: ['Bill', 'John', 'Dave']})).
+      to.equal('names =  Bill - 0 John - 1 Dave - 2');
+    expect(engine.render('no-index', {names: ['Bill', 'John', 'Dave']})).
+      to.equal('names =  Bill John Dave');
   });
 
   it('handles each loops', function() {
     const engine = beard({
       templates: {
-        '/each': 'people = {{each person in people}}{{person.name.first}} {{person.name.last}}! {{end}}'
+        '/with-index': 'people = {{each person, index in people}}{{index}} - {{person.name.first}} {{person.name.last}}! {{end}}',
+        '/no-index': 'people = {{each person in people}}{{person.name.first}} {{person.name.last}}! {{end}}'
       }
     });
     const people = [
@@ -82,7 +87,10 @@ describe('Beard Rendering', function() {
         }
       }
     ];
-    expect(engine.render('each', {people: people})).to.equal('people = Charles Spurgeon! John Calvin! ');
+    expect(engine.render('with-index', {people: people})).
+      to.equal('people = 0 - Charles Spurgeon! 1 - John Calvin! ');
+    expect(engine.render('no-index', {people: people})).
+      to.equal('people = Charles Spurgeon! John Calvin! ');
   });
 
   it('handles conditionals', function() {


### PR DESCRIPTION
This switches the parameters for `for` and `each` loops so that the value name comes before index, i.e.:
```
{{for index, person in people}}{{person}} - {{index}}{{end}}
```
becomes:
```
{{for person, index in people}}{{person}} - {{index}}{{end}}
```

`index` remains an optional parameter.